### PR TITLE
fix missing last flow/substance record

### DIFF
--- a/SPG/R/functions.R
+++ b/SPG/R/functions.R
@@ -203,9 +203,10 @@ pump.trans <- function(flow, V.max, V.min=0, pump.rate) {
     temp.res.sim <- attr(flow, "temp.res.sim")
 
     ## V = Volume of water in 'tank'
-    V <- rep(0, nrow(flow))
+    V <- rep(0, nrow(flow) + 1)
+
     ## S = mass of substance in 'tank'
-    S <- rep(0, nrow(flow))
+    S <- rep(0, nrow(flow) + 1)
 
     ## water flow out of pump
     Q.out <- rep(0, nrow(flow))
@@ -215,7 +216,7 @@ pump.trans <- function(flow, V.max, V.min=0, pump.rate) {
     ## state of pump
     state <- 'off'
     ## mass balances
-    for(t in 2:nrow(flow)) {
+    for(t in 2 : (nrow(flow) + 1)) {
         ## switch pump 'on' if volume is larger than V.max
         if(V[t-1] > V.max) {
             state <- 'on'
@@ -251,7 +252,7 @@ pump.trans <- function(flow, V.max, V.min=0, pump.rate) {
     dimnames(flow.out) <- dimnames(flow)
     class(flow.out) <- "flow"
     attr(flow.out, "temp.res.sim") <- temp.res.sim # store resolution as attribute
-
+    attr(flow.out, "V.sump.left") <- V[t] # store volume left in a pum sump as attribute
     return(flow.out)
 
 }


### PR DESCRIPTION
The last record of inflow was not considered in pumping as pumping is 'one step behind' inflow. V and S vectors are extended and one more loop added. In addition, flow volume left in a pump sump after pumping was added into flow object as a new attribute to enable better testing of mass balance. Here there is a test of the fixed function:
``` R
Q <- rep(10, 100) + rnorm(100,0,1)
Q <- data.frame('Q' = Q, 'S' = Q * .01)
attr(Q, "temp.res.sim") <- 60
plot(Q[ ,1], type='l')
V = sum(Q[ ,1])*60
Qout <- pump.trans(Q, 7777, 0, 23)
V2 <- sum(Qout[ ,1]) * 60 + attr(Qout, "V.in.sump")
print(V)
print(V2)
```